### PR TITLE
Upgrading phpstan & infection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,11 @@
         "friendsofphp/php-cs-fixer": "dev-long-line-fixers",
         "phing/phing": "^2.16",
         "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan": "^0.9.0",
+        "phpstan/phpstan": "^0.10.0",
         "slevomat/coding-standard": "^4.0",
-        "squizlabs/php_codesniffer": "^3.1"
+        "squizlabs/php_codesniffer": "^3.1",
+        "phpstan/phpstan-phpunit": "^0.10.0",
+        "infection/infection": "^0.9@dev"
     },
     "config": {
         "platform": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,3 @@
 parameters:
 	ignoreErrors:
+	    - '#Call to an undefined method object::getConnection\(\).#'


### PR DESCRIPTION
Phpstan 0.10 is out and since it uses nikic/php-parser 4.x, we need to install infection to 0.9 dev version too.